### PR TITLE
Add find_each call with block yield capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Return a list of all contacts
 
     api_client.contact.all
 
+You can execute a block of code while iterating contacts
+
+    api_client.contact.find_each({}, true, 50) do |contacts|
+      # contacts.length === 50
+      contacts.each do |contact|
+        puts contact['Id']
+      end
+    end
+
 You can also pass a query hash
 
     api_client.contact.all({
@@ -67,6 +76,7 @@ Or by passing a query
 ####  Contact Groups
 
 Return a list of all contact groups
+
     api_client.contact_group_assign.all
 
 You can also pass a hash query
@@ -78,6 +88,7 @@ You can also pass a hash query
 ####  Contact Group Assignments
 
 Return a list of all contact group assignments (i.e. contacts with a tag or group)
+
     api_client.contact_group_assign.all
 
 You can also pass a hash query
@@ -89,6 +100,7 @@ You can also pass a hash query
 ####  Contact Group Categories
 
 Return a list of all contact group categories
+
     api_client.contact_group_category.all
 
 You can also pass a hash query

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Return a list of all contacts
 
     api_client.contact.all
 
+You can get a count of all contacts
+
+    api_client.contact.count
+
 You can execute a block of code while iterating contacts
 
     api_client.contact.find_each({}, true, 50) do |contacts|

--- a/lib/infusionsoft/api/models/base.rb
+++ b/lib/infusionsoft/api/models/base.rb
@@ -8,9 +8,18 @@ module Infusionsoft
           @model_name = model_name || 'Base'
         end
 
-        def all(query = {}, paginate = true, page_number = 0)
-          results = @client.connection.call('DataService.query', @client.api_key, self.table_name, 1000, page_number, query, self.fields)
+        def all(query = {}, paginate = true, per_page = 1000, page_number = 0)
+          per_page = [per_page, 1000].min
+          results = @client.connection.call('DataService.query', @client.api_key, self.table_name, per_page, page_number, query, self.fields)
           results.length > 0 && paginate ? results + self.all(query, true, page_number + 1) : results
+        end
+
+        def find_each(query = {}, paginate = true, per_page = 1000, page_number = 0, &block)
+          per_page = [per_page, 1000].min
+          results = @client.connection.call('DataService.query', @client.api_key, self.table_name, per_page, page_number, query, self.fields)
+          yield results
+          return self.find_each(query, true, per_page, page_number + 1, &block) if results.length > 0 && paginate
+          true
         end
 
         def first(query = {})

--- a/lib/infusionsoft/api/models/base.rb
+++ b/lib/infusionsoft/api/models/base.rb
@@ -39,6 +39,10 @@ module Infusionsoft
           end
         end
 
+        def count(query={})
+          @client.connection.call('DataService.count', @client.api_key, self.table_name, query)
+        end
+
         def table_name
           @model_name
         end

--- a/lib/infusionsoft/api/models/base.rb
+++ b/lib/infusionsoft/api/models/base.rb
@@ -11,7 +11,7 @@ module Infusionsoft
         def all(query = {}, paginate = true, per_page = 1000, page_number = 0)
           per_page = [per_page, 1000].min
           results = @client.connection.call('DataService.query', @client.api_key, self.table_name, per_page, page_number, query, self.fields)
-          results.length > 0 && paginate ? results + self.all(query, true, page_number + 1) : results
+          results.length > 0 && paginate ? results + self.all(query, true, per_page, page_number + 1) : results
         end
 
         def find_each(query = {}, paginate = true, per_page = 1000, page_number = 0, &block)


### PR DESCRIPTION
This is an important feature because it allows handling the returned paginated data in smaller chunks. Memory friendly 👍 